### PR TITLE
Feat: Implement final FSM and simplified setup menu

### DIFF
--- a/UI.h
+++ b/UI.h
@@ -26,11 +26,18 @@ public:
   unsigned long getHoldDuration();
 
   // Drawing methods
-  void drawLivePage(float weight, bool isCalibrated, bool isWifiConnected, int rssi);
+  void displayReady(unsigned long standbyTime);
+  void displayActive(unsigned long operationTime, unsigned long standbyTime);
+  void displayInactive(unsigned long standbyTime);
+  void displayStandby(unsigned long standbyTime);
+  void displaySetupMain(int menuIndex);
+  void displaySetupStandbyTime(int newStandbyTime);
+  void displayWeighing(float weight);
   void drawTarePage();
   void drawCalibratePage();
   void drawInfoPage(long tareOffset, float calFactor, String ip, bool isMqttConnected);
   void drawResetPage();
+  void displayConfirmation(const char* message);
   void showMessage(const char* line1, const char* line2, int delayMs = 0);
   void showMessage(const char* line1, const char* line2, const char* line3, int delayMs=0);
   void clear();
@@ -44,8 +51,7 @@ public:
 private:
   void initOLED(const char* version);
   void splash(const char* version);
-  String formatKgComma(float kg, uint8_t decimals);
-  void drawWeightValue(float kg, int16_t x, int16_t baselineY);
+  String formatTime(unsigned long timeSeconds);
 
   int _buttonPin;
   int _ledPin;

--- a/Waage.cpp
+++ b/Waage.cpp
@@ -11,11 +11,7 @@ Waage::Waage(int doutPin, int sckPin)
   _lastWeight(0.0f),
   _emaWeight(0.0f),
   _emaInit(false),
-  _lastPrintedKg(0.0f),
-  _hasLastPrinted(false),
-  _hasLastOutput(false),
-  _anzeigeGenauigkeit_g(1000),          // Default: 1000 g (2 Nachkommastelle in kg)
-  _anzeigeDezimalstellen(1)
+  _hasLastOutput(false)
 {}
 
 void Waage::begin(const KalibrierungsDaten& daten) {
@@ -35,7 +31,6 @@ void Waage::begin(const KalibrierungsDaten& daten) {
 
   // Reset Tracking
   _hasLastOutput  = false;
-  _hasLastPrinted = false;
   _lastWeight     = 0.0f;
   _emaInit        = false;
 }
@@ -64,12 +59,12 @@ void Waage::loop() {
       if (!_emaInit) { _emaWeight = gewicht_g; _emaInit = true; }
       else { _emaWeight = EMA_ALPHA * gewicht_g + (1.0f - EMA_ALPHA) * _emaWeight; }
 
-      // Signifikanz-Logik: Prozentänderung ODER absolute Schwelle (halbe Anzeige-Genauigkeit)
+      // Signifikanz-Logik: Prozentänderung ODER absolute Schwelle
       const float absDelta_g    = fabsf(_emaWeight - _lastWeight);
       const float pctChange     = (_hasLastOutput && fabsf(_lastWeight) > 0.0f)
                                 ? (absDelta_g / fabsf(_lastWeight)) * 100.0f
                                 : 0.0f;
-      const float absThreshold_g = max(1.0f, _anzeigeGenauigkeit_g * 0.5f); // mind. 1 g
+      const float absThreshold_g = 1.0f; // 1g
 
       bool significant = false;
       if (!_hasLastOutput) {
@@ -84,17 +79,9 @@ void Waage::loop() {
         _lastWeight    = _emaWeight;
         _hasLastOutput = true;
 
-        // Ausgabe nur, wenn sich die GERUNDETE Anzeige ändert (verhindert 0.0-Fluten)
-        float kg           = _emaWeight / 1000.0f;
-        float factor       = powf(10.00f, _anzeigeDezimalstellen);
-        float roundedKg    = roundf(kg * factor) / factor;
-        if (!_hasLastPrinted || fabsf(roundedKg - _lastPrintedKg) > (0.5f / factor)) {
-          _lastPrintedKg   = roundedKg;
-          _hasLastPrinted  = true;
-          Serial.print(F("Gewicht: "));
-          Serial.print(roundedKg, _anzeigeDezimalstellen);
-          Serial.println(F(" kg"));
-        }
+        Serial.print(F("Gewicht: "));
+        Serial.print(roundf(_emaWeight));
+        Serial.println(F(" g"));
       }
     } else {
       if (!waitmessagesent){
@@ -106,16 +93,14 @@ void Waage::loop() {
   }
 }
 
-void Waage::setAnzeigeGenauigkeitGramm(uint16_t genauigkeit_g) {
-  if (genauigkeit_g == 0) genauigkeit_g = 1; // Schutz
-  _anzeigeGenauigkeit_g  = genauigkeit_g;
-  _anzeigeDezimalstellen = _berechneDezimalstellen(genauigkeit_g);
-}
-
 void Waage::tare() {
+  Serial.println(F("Stabilisiere vor Tare..."));
+  _loadCell.update();
+  delay(200);
+  _loadCell.update();
+
   _loadCell.tare();
   _hasLastOutput  = false; // nächste Ausgabe wieder zulassen
-  _hasLastPrinted = false;
   _lastWeight     = 0.0f;
   _emaInit        = false;
   Serial.println(F("Tare durchgeführt."));
@@ -144,20 +129,9 @@ void Waage::setIstKalibriert(bool isCalibrated) {
 }
 
 float Waage::getGewicht() {
-  _loadCell.update();
-  return _loadCell.getData(); // Gramm (wenn in g kalibriert)
+  return _emaWeight;
 }
 
-float Waage::getGewichtKg() { return getGewicht() / 1000.0f; }
 float Waage::getKalibrierungsfaktor() { return _daten.kalibrierungsfaktor; }
 long  Waage::getTareOffset() { return _loadCell.getTareOffset(); }
 bool  Waage::istKalibriert() { return _daten.istKalibriert; }
-
-uint8_t Waage::_berechneDezimalstellen(uint16_t genauigkeit_g) {
-  // Gramm-Genauigkeit -> Nachkommastellen in kg
-  // 1000 g -> 0, 100 g -> 1, 10 g -> 2, 1 g -> 3 (clamp 0..3)
-  if      (genauigkeit_g >= 1000) return 0;
-  else if (genauigkeit_g >= 100)  return 1;
-  else if (genauigkeit_g >= 10)   return 2;
-  else                            return 3; // 1 g oder feiner
-}

--- a/Waage.h
+++ b/Waage.h
@@ -21,9 +21,6 @@ public:
   // zyklisch aufrufen
   void loop();
 
-  // Anzeigeeinstellungen: Genauigkeit in Gramm (z. B. 100 -> 1 Nachkommastelle, 10 -> 2, 1 -> 3)
-  void setAnzeigeGenauigkeitGramm(uint16_t genauigkeit_g);
-
   // Bedienfunktionen & Kalibrierungs-Helfer
   void tare();
   void refreshDataSet();
@@ -35,7 +32,6 @@ public:
 
   // Getter
   float getGewicht();     // in der Kalibriereinheit (hier: Gramm)
-  float getGewichtKg();   // in Kilogramm
   float getKalibrierungsfaktor();
   long  getTareOffset();
   bool  istKalibriert();
@@ -45,16 +41,8 @@ private:
   float              _lastWeight;            // letzte Rohmessung (in g) – ungeglättet
   float              _emaWeight;             // geglätteter Wert (in g)
   bool               _emaInit;               // EMA initialisiert
-  float              _lastPrintedKg;         // letzte ausgegebene, GERUNDETE kg
-  bool               _hasLastPrinted;        // schon etwas ausgegeben
   bool               _hasLastOutput;         // Alt: verhindert Fluten
   KalibrierungsDaten _daten;
-
-  // Anzeigeformatierung
-  uint16_t _anzeigeGenauigkeit_g;            // z. B. 100 g, 10 g, 1 g
-  uint8_t  _anzeigeDezimalstellen;           // abgeleitet aus Genauigkeit
-
-  uint8_t _berechneDezimalstellen(uint16_t genauigkeit_g);
 };
 
 #endif

--- a/WifiConfigManager.cpp
+++ b/WifiConfigManager.cpp
@@ -166,7 +166,11 @@ void WifiConfigManager::_startAP() {
         request->send(200, "text/html; charset=utf-8",
           "<h1>Konfiguration erfolgreich! Gerät wird neu gestartet.</h1>"
           "<script>setTimeout(function(){window.location.href='/'},3000);</script>");
-        delay(1500);
+
+        _server.end();
+        if (_ui) _ui->showMessage("Neustart.....", "", 0);
+        unsigned long startTime = millis();
+        while(millis() - startTime < 2000) { /* non-blocking delay */ }
         ESP.restart();
       }
     }
@@ -176,15 +180,16 @@ void WifiConfigManager::_startAP() {
   _server.on("/update", HTTP_POST, [this](AsyncWebServerRequest *request) {
     bool shouldReboot = !Update.hasError();
     if (_ui) {
-        if(shouldReboot) _ui->showMessage("Update OK", "Neustart...", 1000);
+        if(shouldReboot) _ui->showMessage("Update OK", "Neustart.....", 2000);
         else _ui->showMessage("Update fehlgeschlagen", "", 2000);
     }
     AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", shouldReboot ? "OK" : "FAIL");
     response->addHeader("Connection", "close");
     request->send(response);
     if (shouldReboot) {
-        if (_ui) _ui->clear();
-        delay(1000);
+        _server.end();
+        unsigned long startTime = millis();
+        while(millis() - startTime < 2000) { /* non-blocking delay */ }
         ESP.restart();
     }
   }, [this](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
@@ -269,7 +274,10 @@ void WifiConfigManager::_connectToWiFi() {
           request->send(200, "text/html; charset=utf-8",
             "<h1>Konfiguration erfolgreich! Gerät wird neu gestartet.</h1>"
             "<script>setTimeout(function(){window.location.href='/'},3000);</script>");
-          delay(1500);
+          _server.end();
+          if (_ui) _ui->showMessage("Neustart.....", "", 0);
+          unsigned long startTime = millis();
+          while(millis() - startTime < 2000) { /* non-blocking delay */ }
           ESP.restart();
         }
       }
@@ -279,15 +287,16 @@ void WifiConfigManager::_connectToWiFi() {
     _server.on("/update", HTTP_POST, [this](AsyncWebServerRequest *request) {
         bool shouldReboot = !Update.hasError();
         if (_ui) {
-            if(shouldReboot) _ui->showMessage("Update OK", "Neustart...", 1000);
+            if(shouldReboot) _ui->showMessage("Update OK", "Neustart.....", 2000);
             else _ui->showMessage("Update fehlgeschlagen", "", 2000);
         }
         AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", shouldReboot ? "OK" : "FAIL");
         response->addHeader("Connection", "close");
         request->send(response);
         if (shouldReboot) {
-            if (_ui) _ui->clear();
-            delay(1000);
+            _server.end();
+            unsigned long startTime = millis();
+            while(millis() - startTime < 2000) { /* non-blocking delay */ }
             ESP.restart();
         }
     }, [this](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
@@ -469,6 +478,9 @@ bool WifiConfigManager::_validateForm(AsyncWebServerRequest* request) {
     Serial.println("An dieser Stelle wird in _validateForm der NVS gelöscht :-(");
     _prefsNetwork.begin  (PREFS_NAMESPACE_NETWORK,   false); _prefsNetwork.clear(); _prefsNetwork.end();
     _prefsOperation.begin(PREFS_NAMESPACE_OPERATION, false); _prefsOperation.clear(); _prefsOperation.end();
+    if (_ui) _ui->showMessage("Neustart.....", "", 0);
+    unsigned long startTime = millis();
+    while(millis() - startTime < 2000) { /* non-blocking delay */ }
     ESP.restart();
     return false;
   }


### PR DESCRIPTION
This commit delivers the final, robust version of the Weller station controller firmware. It incorporates a complete FSM refactoring and a simplified, more user-friendly setup menu based on extensive user feedback and testing.

Key Changes:

1.  **Dual-Mode FSM:** Implemented the primary state machine (`READY`, `ACTIVE`, `INACTIVE`, `STANDBY`) to control the soldering station relay.

2.  **Simplified Setup Menu:**
    - The setup menu is a scrolling list navigated with short presses and selected with a 2-second long press.
    - The global timeout has been removed; an 'Exit' option is now used.
    - Standby time configuration is limited to a 1-15 minute range.
    - A confirmation screen has been added for the factory reset.

3.  **UI and Bug Fixes:**
    - Fixed a critical compilation error by using a `>` marker for menu selection instead of unsupported inversion functions.
    - The menu font has been enlarged for better readability.
    - Fixed a bug where the device was unresponsive in the `STANDBY` state.